### PR TITLE
调整二维码位置

### DIFF
--- a/templates/static/js/script.js
+++ b/templates/static/js/script.js
@@ -100,7 +100,7 @@ $(document).ready(function() {
 				closeBtn: 1,
 				shift: 2,
 				shadeClose: true,
-				content: '<img style="width: 100%; height: 100%;" src="http://pan.baidu.com/share/qrcode?w=300&h=300&url=' + str + '"/><div style="position: relative; overflow: auto; text-align: center; margin-bottom: 10px; font-size: 12px;">请使用 Shadowsocks 客户端进行扫描</div>'
+				content: '<img style="position: relative; left: 600px; width: 100%; height: 100%;" src="http://pan.baidu.com/share/qrcode?w=300&h=300&url=' + str + '"/><div style="position: relative; overflow: auto; text-align: center; margin-bottom: 10px; font-size: 12px;">请使用 Shadowsocks 客户端进行扫描</div>'
 			});
 		});
 	});


### PR DESCRIPTION
更新script.js文件，调整二维码位置信息。
Chrome浏览器需要清除cookies才能显示出正确的二维码，默认从上次缓存读取。